### PR TITLE
Improve Home Assistant compatibility: numeric-only output, 15-min caching, fewer logins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
-# State file and logs
-state.json
+# Gym API state and temp files
+gym_api_info.json
+gym_api_state.json
+gym_api_state.lwp
+*.tmp
+*.log
 cron.log
 cookies.json
-state.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -33,8 +36,6 @@ share/python-wheels/
 MANIFEST
 
 # PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
 
@@ -89,40 +90,26 @@ profile_default/
 ipython_config.py
 
 # pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
 # .python-version
 
 # pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
 #Pipfile.lock
 
 # poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
 # pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
 #pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
 
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+# PEP 582
 __pypackages__/
 
-# Celery stuff
+# Celery
 celerybeat-schedule
 celerybeat.pid
 
-# SageMath parsed files
+# SageMath
 *.sage.py
 
 # Environments
@@ -134,14 +121,14 @@ ENV/
 env.bak/
 venv.bak/
 
-# Spyder project settings
+# Spyder
 .spyderproject
 .spyproject
 
-# Rope project settings
+# Rope
 .ropeproject
 
-# mkdocs documentation
+# mkdocs
 /site
 
 # mypy
@@ -149,18 +136,14 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
-# Pyre type checker
+# Pyre
 .pyre/
 
-# pytype static type analyzer
+# pytype
 .pytype/
 
-# Cython debug symbols
+# Cython
 cython_debug/
 
 # PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/

--- a/README.md
+++ b/README.md
@@ -1,50 +1,50 @@
-## README.md
-Gym Group Python API
-This script is a fork of the Gym Group Python API originally written by joestanding. It has been enhanced to be more efficient and resilient for continuous use, particularly in environments like Home Assistant.
+# Gym Group Python API (HA-friendly fork)
 
-## Overview
-This Python script interacts with The Gym Group's private API to retrieve the current occupancy of a specified home gym. It's designed to be run as a service or sensor, providing a real-time (or near real-time) count of how many people are in your gym.
+This fork builds on the original project by **@joestanding** and focuses on being efficient, resilient, and friendly for continuous use — especially with **Home Assistant**.
 
-## Key Features
-Efficient API Interaction: The script now caches session information, avoiding the need to log in on every execution.
+## What it does
 
-Request Caching: To reduce API calls, the script stores the last-known occupancy value and only requests new data after a set period.
+Fetches the **currentCapacity** (people count) for your **home gym** from The Gym Group’s private mobile API and prints **only a number** to stdout — ideal for HA `command_line` sensors.
 
-Automatic Re-authentication: The script can automatically detect an expired session and re-login without manual intervention.
+## Key improvements
 
-Robust Error Handling: It includes a retry mechanism for transient network issues and a graceful fallback to a cached value if a data fetch fails.
+- **Numeric-only output** for HA: stdout is only the people count; errors go to stderr.
+- **15-minute caching (TTL)**: avoids unnecessary API calls.
+- **Session reuse**: cookies + user IDs persisted; **login only when needed** (on 401/403).
+- **ETag support**: sends `If-None-Match` to allow `304 Not Modified`.
+- **Silent retries**: quick retry/backoff for transient 429/5xx/timeouts.
+- **Graceful fallback**: if the API hiccups, returns **last known value**.
 
-## Installation & Usage
-Clone the Repository:
+## Installation
 
-Bash
+bash
+git clone https://github.com/brutus6/gymgroup-api.git
+cd gymgroup-api
+pip install -r requirements.txt   # or: pip install requests PyYAML
 
-git clone [your repository URL]
-cd [your repository name]
-Install Dependencies:
-This script requires the requests and PyYAML libraries. You can install them using pip:
 
-Bash
+## Usage with Home Assistant
 
-pip install requests PyYAML
-Configure Credentials:
-You must create a secrets.yaml file in the same directory as the script. This file will store your Gym Group login details.
+Example command_line sensor in configuration.yaml:
 
-secrets.yaml should look like this:
+command_line:
+  - sensor:
+      name: "Gym Occupancy Raw"
+      command: "python3 /config/gym_occupancy.py"
+      unit_of_measurement: "people"
+      scan_interval: 900
+      value_template: "{{ value | int(0) }}"
 
-YAML
+## Configuration
 
-gym_group_username: "your_username"
-gym_group_password: "your_password"
-Note: If you are using this with Home Assistant, ensure the secrets_path variable in the script is correctly set to your Home Assistant configuration directory.
+Create a secrets.yaml file in your Home Assistant config directory with:
 
-Run the Script:
-You can run the script from your terminal:
+gym_group_username: "your_email@example.com"
+gym_group_password: "your_pin_or_password"
 
-Bash
-
-python your_script_name.py
-The script will print the current gym occupancy to standard output. Any errors will be printed to standard error.
+Update the secrets_path variable in the script if it’s not in /config/secrets.yaml.
 
 ## Contributing
-I welcome contributions to this project. If you have suggestions or improvements, please submit a pull request. This script was forked from the original work of joestanding.
+
+I welcome contributions to this project. If you have suggestions or improvements, please submit a pull request. This script was forked from the original work of  **@joestanding**.
+

--- a/README.md
+++ b/README.md
@@ -1,12 +1,50 @@
-# Gym Group Python API
+## README.md
+Gym Group Python API
+This script is a fork of the Gym Group Python API originally written by joestanding. It has been enhanced to be more efficient and resilient for continuous use, particularly in environments like Home Assistant.
 
-A quick Python library I use to interface with the Gym Group mobile API, to retrieve information such as current gym occupancy and your gym attendance statistics.
+## Overview
+This Python script interacts with The Gym Group's private API to retrieve the current occupancy of a specified home gym. It's designed to be run as a service or sensor, providing a real-time (or near real-time) count of how many people are in your gym.
 
-## Simple Usage
-```
-from gymapi import GymGroupAPI
-gym_api = GymGroupAPI('USERNAME', 'PASSWORD')
+## Key Features
+Efficient API Interaction: The script now caches session information, avoiding the need to log in on every execution.
 
-# Get gym busyness - user's home gym UUID is stored in the 'home_gym' property.
-occupancy = gym_api.get_gym_occupancy(gym_api.home_gym)
-```
+Request Caching: To reduce API calls, the script stores the last-known occupancy value and only requests new data after a set period.
+
+Automatic Re-authentication: The script can automatically detect an expired session and re-login without manual intervention.
+
+Robust Error Handling: It includes a retry mechanism for transient network issues and a graceful fallback to a cached value if a data fetch fails.
+
+## Installation & Usage
+Clone the Repository:
+
+Bash
+
+git clone [your repository URL]
+cd [your repository name]
+Install Dependencies:
+This script requires the requests and PyYAML libraries. You can install them using pip:
+
+Bash
+
+pip install requests PyYAML
+Configure Credentials:
+You must create a secrets.yaml file in the same directory as the script. This file will store your Gym Group login details.
+
+secrets.yaml should look like this:
+
+YAML
+
+gym_group_username: "your_username"
+gym_group_password: "your_password"
+Note: If you are using this with Home Assistant, ensure the secrets_path variable in the script is correctly set to your Home Assistant configuration directory.
+
+Run the Script:
+You can run the script from your terminal:
+
+Bash
+
+python your_script_name.py
+The script will print the current gym occupancy to standard output. Any errors will be printed to standard error.
+
+## Contributing
+I welcome contributions to this project. If you have suggestions or improvements, please submit a pull request. This script was forked from the original work of joestanding.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## README.md
+
 # Gym Group Python API (HA-friendly fork)
 
 This fork builds on the original project by **@joestanding** and focuses on being efficient, resilient, and friendly for continuous use — especially with **Home Assistant**.
@@ -30,7 +32,7 @@ Example command_line sensor in configuration.yaml:
 command_line:
   - sensor:
       name: "Gym Occupancy Raw"
-      command: "python3 /config/gym_occupancy.py"
+      command: "python3 /config/gymapi.py"
       unit_of_measurement: "people"
       scan_interval: 900
       value_template: "{{ value | int(0) }}"

--- a/gymapi.py
+++ b/gymapi.py
@@ -1,166 +1,235 @@
-import requests
-import json
-import logging
 import sys
+import os
+import json
+import time
+import yaml
+import requests
+import http.cookiejar as cookiejar
 from requests.compat import urljoin
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+# ---------- Paths (next to script) ----------
+HERE = os.path.dirname(os.path.abspath(__file__))
+STATE_COOKIES = os.path.join(HERE, "gym_api_state.lwp")
+STATE_INFO    = os.path.join(HERE, "gym_api_info.json")
 
-# =========================================================================== #
+# ---------- Tuning ----------
+CACHE_TTL_SECONDS = 900        # 15 minutes
+MIN_LOGIN_RETRY_SECONDS = 300  # avoid hammering login on repeated failures
 
 class GymGroupAPI:
-
-    # ----------------------------------------------------------------------- #
-
     BASE_URL = 'https://thegymgroup.netpulse.com/np/'
     ENDPOINT_LOGIN = 'exerciser/login'
-    STATE_FILE = 'state.json'
-    REQ_HEADERS = {
+    HEADERS = {
         'Accept': 'application/json',
-        'Accept-Encoding': 'gzip',
-        'Connection': 'Keep-Alive',
-        'User-Agent': 'okhttp/3.12.3',
+        'User-Agent': 'okhttp/4.12.0',
         'X-NP-API-Version': '1.5',
-        'X-NP-App-Version': '5.0',
-        "X-NP-User-Agent": "clientType=MOBILE_DEVICE; " \
-                "devicePlatform=ANDROID; " \
-                "deviceUid=; " \
-                "applicationName=The Gym Group; " \
-                "applicationVersion=5.0; " \
-                "applicationVersionCode=38"
+        'X-NP-App-Version': '9999.0',
+        "X-NP-User-Agent": (
+            "clientType=MOBILE_DEVICE; "
+            "devicePlatform=ANDROID; "
+            "deviceUid=; "
+            "applicationName=The Gym Group; "
+            "applicationVersion=9999.0; "
+            "applicationVersionCode=999999"
+        )
     }
-
-    # ----------------------------------------------------------------------- #
 
     def __init__(self, username, password):
         self.username   = username
         self.password   = password
         self.user_id    = None
         self.home_gym   = None
-        self.api_sess   = requests.session()
-        self.api_sess.headers = self.REQ_HEADERS
+        self.etag       = None
+        self.last_value = None
+        self.last_ts    = 0.0
+        self.last_login_attempt = 0.0
 
-        if not self._load_state():
-            logger.debug("State file didn't exist or failed to load")
-            if not self.login():
-                logger.error("Authentication failed! Check credentials.")
+        self.session = requests.Session()
+        self.session.headers.update(self._strip_accept_encoding(self.HEADERS))
 
-    # ----------------------------------------------------------------------- #
+        # --- Silent HTTP retry adapter (handles brief blips without noise) ---
+        retries = Retry(
+            total=2,
+            backoff_factor=0.5,  # ~0.5s then ~1s
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=frozenset(["GET", "POST"])
+        )
+        adapter = HTTPAdapter(max_retries=retries)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
 
-    def _api_req(self, method, endpoint, data=None, retry_on_auth_fail=True):
-        if method != 'POST' and method !='GET':
-            logger.error("Invalid HTTP method specified to _api_req!")
-            return False
-
-        final_url = urljoin(self.BASE_URL, endpoint)
-        logger.debug(f"API {method} to URL '{final_url}'..")
-
+        # Persist cookies with domain/path
+        self.session.cookies = cookiejar.LWPCookieJar(STATE_COOKIES)
         try:
-            if method.upper() == 'POST':
-                response = self.api_sess.post(final_url, data=data)
-                response.raise_for_status()
-            elif method.upper() == 'GET':
-                response = self.api_sess.get(final_url)
-                response.raise_for_status()
-        except requests.exceptions.HTTPError as exc:
-            logger.error(f"HTTP error {response.status_code} on API " \
-                    f"{method} Error: {exc}")
-            if response.status_code == 403 and retry_on_auth_fail:
-                logger.error("Server returned auth. failure, logging in..")
-                if not self.login():
-                    logger.error("Authentication retry failed!")
-                    return False
-                return self._api_req(method, endpoint, data, False)
-            return False
-        except requests.exceptions.ConnectionError as exc:
-            logger.error(f"Connection error on API {method}! Error: {exc}")
-            return False
-        except requests.exceptions.Timeout as exc:
-            logger.error(f"Timeout error on API {method}! Error: {exc}")
-            return False
-        except requests.exceptions.RequestException as exc:
-            logger.error(f"Misc. error on API {method}! Error: {exc}")
-            return False
+            self.session.cookies.load(ignore_discard=True, ignore_expires=False)
+        except FileNotFoundError:
+            pass
+        except Exception:
+            # corrupted jar -> start fresh silently
+            self.session.cookies = cookiejar.LWPCookieJar(STATE_COOKIES)
 
-        logger.debug(f"API {method} to '{endpoint}' succeeded!")
-        logger.debug(f"Response: {response}")
+        self._load_info()
 
-        return response
+    @staticmethod
+    def _strip_accept_encoding(h):
+        h2 = dict(h)
+        h2.pop('Accept-Encoding', None)
+        return h2
 
-    # ----------------------------------------------------------------------- #
-
-    def _load_state(self):
+    # ----- State I/O -----
+    def _load_info(self):
         try:
-            with open(self.STATE_FILE, 'r') as file_handle:
-                state = json.load(file_handle)
-                self.api_sess.cookies.update(state['cookies'])
-                self.user_id  = state['login_resp']['uuid']
-                self.home_gym = state['login_resp']['homeClubUuid']
-                return True
-        except Exception as exc:
-            logger.error(f"Exception occurred loading cookie jar: {exc}")
+            with open(STATE_INFO, 'r') as f:
+                d = json.load(f)
+            self.user_id    = d.get('user_id')
+            self.home_gym   = d.get('home_gym')
+            self.etag       = d.get('etag')
+            self.last_value = d.get('last_value')
+            self.last_ts    = float(d.get('last_ts', 0))
+            self.last_login_attempt = float(d.get('last_login_attempt', 0))
+        except Exception:
+            self.user_id = self.home_gym = self.etag = None
+            self.last_value, self.last_ts, self.last_login_attempt = None, 0.0, 0.0
+
+    def _save_info(self):
+        try:
+            tmp = f"{STATE_INFO}.tmp"
+            payload = {
+                'user_id': self.user_id,
+                'home_gym': self.home_gym,
+                'etag': self.etag,
+                'last_value': self.last_value,
+                'last_ts': self.last_ts,
+                'last_login_attempt': self.last_login_attempt,
+            }
+            with open(tmp, 'w') as f:
+                json.dump(payload, f)
+            os.replace(tmp, STATE_INFO)
+            try:
+                os.chmod(STATE_INFO, 0o600)
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+    def _save_cookies(self):
+        try:
+            self.session.cookies.save(ignore_discard=True, ignore_expires=True)
+        except Exception:
+            pass
+
+    # ----- HTTP -----
+    def _api(self, method, endpoint, *, headers=None, data=None, retry_auth=True):
+        url = urljoin(self.BASE_URL, endpoint)
+        try:
+            if method == 'GET':
+                resp = self.session.get(url, headers=headers, timeout=15)
+            else:
+                resp = self.session.post(url, data=data, headers=headers, timeout=15)
+            if resp.status_code in (401, 403) and retry_auth:
+                if self._maybe_login():
+                    return self._api(method, endpoint, headers=headers, data=data, retry_auth=False)
+            resp.raise_for_status()
+            return resp
+        except requests.exceptions.RequestException as e:
+            raise Exception(str(e))
+
+    # ----- Auth -----
+    def _maybe_login(self):
+        now = time.time()
+        if now - self.last_login_attempt < MIN_LOGIN_RETRY_SECONDS:
             return False
-
-    # ----------------------------------------------------------------------- #
-
-    def _save_state(self, state):
-        with open(self.STATE_FILE, 'w') as file_handle:
-            json.dump(state, file_handle)
-
-    # ----------------------------------------------------------------------- #
+        self.last_login_attempt = now
+        self._save_info()
+        return self.login()
 
     def login(self):
-        if not self.username or not self.password:
-            logger.error("Username or password were not specified!")
-            return False
-
-        logger.debug(f"Authenticating with username '{self.username}'")
-        response = self._api_req('POST', self.ENDPOINT_LOGIN, {
-            'username': self.username,
-            'password': self.password
-        })
-
-        if not response:
-            logger.error("There was a failure to log in!")
-            return False
-
         try:
-            resp_json = response.json()
-        except json.JSONDecodeError as exc:
-            logger.error(f"Login response was not valid JSON! Exc: {exc}")
+            resp = self._api('POST', self.ENDPOINT_LOGIN,
+                             data={'username': self.username, 'password': self.password},
+                             retry_auth=False)
+            info = resp.json()
+            self.user_id = info['uuid']
+            self.home_gym = info['homeClubUuid']
+            self._save_cookies()
+            self._save_info()
+            return True
+        except Exception:
             return False
 
-        self.user_id  = resp_json['uuid']
-        self.home_gym = resp_json['homeClubUuid']
+    # ----- API -----
+    def get_gym_occupancy(self):
+        now = time.time()
+        # Serve cached value if within TTL
+        if self.last_value is not None and (now - self.last_ts) < CACHE_TTL_SECONDS:
+            return self.last_value
 
-        logger.debug(f"Authenticated as UUID: {self.user_id}")
-        logger.debug(f"Storing cookies to disk..")
-        cookies = requests.utils.dict_from_cookiejar(self.api_sess.cookies)
+        if not self.user_id or not self.home_gym:
+            if not self._maybe_login():
+                if self.last_value is not None:
+                    return self.last_value
+                raise Exception("Login required and throttled/failed")
 
-        state = { 'cookies': cookies, 'login_resp': resp_json }
-        self._save_state(state)
+        endpoint = f"thegymgroup/v1.0/exerciser/{self.user_id}/gym-busyness?gymLocationId={self.home_gym}"
+        hdrs = {}
+        if self.etag:
+            hdrs['If-None-Match'] = self.etag
 
-        return True
+        resp = self._api('GET', endpoint, headers=hdrs)
 
-    # ----------------------------------------------------------------------- #
+        if resp.status_code == 304 and self.last_value is not None:
+            self.last_ts = now
+            self._save_info()
+            return self.last_value
 
-    def get_gym_occupancy(self, gym_uuid):
-        endpoint = f"thegymgroup/v1.0/exerciser/{self.user_id}/gym-busyness?" \
-                f"gymLocationId={gym_uuid}"
-        response = self._api_req('GET', endpoint)
+        data = resp.json()
 
-        if not response:
-            logger.error("Failed to retrieve gym occupancy!")
-            return False
-
+        # PEOPLE COUNT parsing (no clamping)
+        raw = data.get('currentCapacity')
         try:
-            resp_json = response.json()
-        except json.JSONDecodeError as exc:
-            logger.error(f"Gym occupancy response not valid JSON! Exc: {exc}")
-            return False
+            num = int(float(str(raw)))
+        except Exception:
+            num = None
 
-        logger.debug(f"Gym occupancy JSON: {json}")
-        return resp_json.get('currentCapacity')
+        new_etag = resp.headers.get('ETag') or resp.headers.get('Etag')
+        if new_etag:
+            self.etag = new_etag
 
-# =========================================================================== #
+        if num is not None:
+            self.last_value = num
+            self.last_ts = now
+            self._save_info()
+            return self.last_value
+
+        # if API response is weird, keep previous value if we have one
+        if self.last_value is not None:
+            self.last_ts = now
+            self._save_info()
+            return self.last_value
+
+        raise Exception("Occupancy missing and no cached value")
+
+# ----- Entry point -----
+if __name__ == "__main__":
+    secrets_path = '/config/secrets.yaml'
+    try:
+        with open(secrets_path) as f:
+            secrets = yaml.safe_load(f)
+        USERNAME = secrets['gym_group_username']
+        PASSWORD = secrets['gym_group_password']
+    except Exception as e:
+        print(f"Error: secrets problem: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    api = GymGroupAPI(USERNAME, PASSWORD)
+    try:
+        value = api.get_gym_occupancy()
+        print(value)  # stdout ONLY the number (HA-safe)
+    except Exception as e:
+        if api.last_value is not None:
+            print(api.last_value)  # final fallback: last known people count
+            sys.exit(0)
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Summary

First off — a huge thank you to @joestanding for the original work on this project. 🙏
It’s been a real help, and this little fork is simply my attempt to make it a touch more “Home-Assistant-friendly” and a bit more forgiving when left running day in, day out.

What’s changed
Keeps hold of your session – Cookies and user info are saved locally so we don’t have to log in every time.

A bit less chatty – Adds a 15-minute cache, so we only ask the API when we really need to.

One door in and out – All requests now go through one _api() method, which:

Silently retries if the network has a little wobble.

Logs back in automatically if your session has wandered off.

No login frenzy – Won’t keep bashing the login endpoint if it’s already failed recently.

Grace under pressure – If the API does go quiet, we’ll politely hand back the last good number rather than sulking.

Why
The aim here is simply to:

Reduce the load on the API.

Keep the data flowing smoothly in Home Assistant.

Make the script “set-and-forget” reliable without nagging the server unnecessarily.

If you’re happy with it, I’ll keep this in sync with upstream in case anything changes on the Gym Group side.

Thanks again for the original code — it made this much easier. 🍵